### PR TITLE
Added maven configuration to stop Jetty servers using the jetty:stop plugin

### DIFF
--- a/harvest-agent-h3/pom.xml
+++ b/harvest-agent-h3/pom.xml
@@ -124,6 +124,8 @@
 				<artifactId>jetty-maven-plugin</artifactId>
 				<version>7.5.4.v20111024</version>
 				<configuration>
+					<stopKey>${agent.stopKey}</stopKey>
+					<stopPort>${agent.stopPort}</stopPort>
 					<jettyXml>${project.build.directory}/jetty-jmx.xml</jettyXml>
 					<webApp>
 						<contextPath>/harvest-agent-h3</contextPath>

--- a/wct-core/pom.xml
+++ b/wct-core/pom.xml
@@ -244,6 +244,8 @@
 				<artifactId>jetty-maven-plugin</artifactId>
 				<version>7.5.4.v20111024</version>
 				<configuration>
+					<stopKey>${core.stopKey}</stopKey>
+					<stopPort>${core.stopPort}</stopPort>
 					<webApp>
 						<contextPath>/wct</contextPath>
 						<jettyEnvXml>${project.build.directory}/jetty-env.xml</jettyEnvXml>

--- a/wct-store/pom.xml
+++ b/wct-store/pom.xml
@@ -102,6 +102,8 @@
 				<artifactId>jetty-maven-plugin</artifactId>
 				<version>7.5.4.v20111024</version>
 				<configuration>
+					<stopKey>${das.stopKey}</stopKey>
+					<stopPort>${das.stopPort}</stopPort>
 					<webApp>
 						<contextPath>/wct-store</contextPath>
 						<resourceBases>


### PR DESCRIPTION
To stop a running maven server the new stop key and stop ports need to be specified e.g.

mvn jetty:stop -Dcore.port=8080 -Dagent.port=8081 -Ddas.port=8082 -Dcore.stopKey=stop_wct_core -Dcore.stopPort=8090 -Ddas.stopKey=stop_wct_store -Ddas.stopPort=8092 -Dagent.stopKey=stop_h3 -Dagent.stopPort=8091 -Pmysql -f pom.xml