### PR TITLE
Make email validation regex more robust

### DIFF
--- a/wct-core/src/main/java/org/webcurator/ui/common/validation/ValidatorUtil.java
+++ b/wct-core/src/main/java/org/webcurator/ui/common/validation/ValidatorUtil.java
@@ -49,7 +49,7 @@ import org.webcurator.ui.agent.command.BandwidthRestrictionsCommand;
 public final class ValidatorUtil {
     
     public final static String EMAIL_VALIDATION_REGEX = 
-        "^[_a-zA-Z0-9-]+(\\.[_a-zA-Z0-9-]+)*@[a-zA-Z0-9-]+(\\.[a-zA-Z0-9-]+)*(\\.[a-zA-Z]{2,4})$";
+        "^[_a-zA-Z0-9-]+(\\.[_a-zA-Z0-9-]+)*@[a-zA-Z0-9-]+(\\.[a-zA-Z0-9-]+)*(\\.[a-zA-Z]{2,24})$";
     
     
     /**


### PR DESCRIPTION
Hi,

this PR makes the email validation regex more robust. As discussed in #7, new tlds can have a length > 4. Currently, one of the longest tlds is *.vermögensberatung*.

All tlds can be fetched via:

```bash
curl -s http://data.iana.org/TLD/tlds-alpha-by-domain.txt | tail -n+2
```

With this PR the max. tld length is set from 4 to 24 in the email validation regex.