### PR TITLE
HarvesterH3 H3 instance configurable.

### DIFF
--- a/harvest-agent-h3/build/local_config.properties
+++ b/harvest-agent-h3/build/local_config.properties
@@ -22,3 +22,15 @@ agent.name=H3 Agent
 agent.service=/harvest-agent-h3/services/urn:HarvestAgent
 # the name of the harvest agent log reader web service
 agent.logReaderService=/harvest-agent-h3/services/urn:LogReader
+# The H3 instance host.
+h3Instance.host=localhost
+# The H3 instance port.
+h3Instance.port=8443
+# The H3 instance full path and filename for the keystore file.
+h3Instance.keyStoreFile=
+# The H3 instance password for the keyStore file
+h3Instance.keyStorePassword=
+# The H3 instance userName.
+h3Instance.userName=admin
+# The H3 instance password.
+h3Instance.password=admin

--- a/harvest-agent-h3/src/main/java/org/webcurator/core/common/Constants.java
+++ b/harvest-agent-h3/src/main/java/org/webcurator/core/common/Constants.java
@@ -28,7 +28,9 @@ public final class Constants {
     public static final String BEAN_NOTIFIER = "harvestCoordinatorNotifier";
     /** the name of the harvest complete config bean. */
     public static final String BEAN_HARVEST_COMPLETE_CONFIG = "harvestCompleteConfig";
-    
+    /** the name of the heritrix3 wrapper configuration bean. */
+    public static final String HERITRIX3_WRAPPER_CONFIGURATION = "heritrix3WrapperConfiguration";
+
     /** the name of the Logs directory. */
     public static final String DIR_LOGS = "logs";
     /** the name of the reports directory. */

--- a/harvest-agent-h3/src/main/java/org/webcurator/core/harvester/agent/Heritrix3WrapperConfiguration.java
+++ b/harvest-agent-h3/src/main/java/org/webcurator/core/harvester/agent/Heritrix3WrapperConfiguration.java
@@ -1,0 +1,66 @@
+package org.webcurator.core.harvester.agent;
+
+import java.io.File;
+
+public class Heritrix3WrapperConfiguration {
+    /** H3 instance host name or ip address that the core knows about. */
+    private String host = "";
+    /** The port the H3 instance is listening on for http connections */
+    private int port = 8443;
+    /** The full path and filename for the keystore file. */
+    private File keyStoreFile = null;
+    /** The password for the keystore file. */
+    private String keyStorePassword = "";
+    /** The userName for the H3 instance. */
+    private String userName = "admin";
+    /** The password for the keystore file. */
+    private String password = "admin";
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public File getKeyStoreFile() {
+        return keyStoreFile;
+    }
+
+    public void setKeyStoreFile(File keyStoreFile) {
+        this.keyStoreFile = keyStoreFile;
+    }
+
+    public String getKeyStorePassword() {
+        return keyStorePassword;
+    }
+
+    public void setKeyStorePassword(String keyStorePassword) {
+        this.keyStorePassword = keyStorePassword;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/harvest-agent-h3/src/main/resources/wct-agent.properties
+++ b/harvest-agent-h3/src/main/resources/wct-agent.properties
@@ -21,6 +21,20 @@ harvestAgent.alertThreshold=200
 # whether to attempt to recover running harvests from H3 instance on startup.
 harvestAgent.attemptHarvestRecovery=true
 
+# Heritrix3 Wrapper Configuration
+# The H3 instance host.
+h3Wrapper.host=${h3Instance.host}
+# The H3 instance port.
+h3Wrapper.port=${h3Instance.port}
+# The H3 instance full path and filename for the keystore file.
+h3Wrapper.keyStoreFile=${h3Instance.keyStoreFile}
+# The H3 instance password for the keyStore file
+h3Wrapper.keyStorePassword=${h3Instance.keyStorePassword}
+# The H3 instance userName.
+h3Wrapper.userName=${h3Instance.userName}
+# The H3 instance password.
+h3Wrapper.password=${h3Instance.password}
+
 
 #HarvestCoordinatorNotifier
 

--- a/harvest-agent-h3/src/main/webapp/WEB-INF/classes/wct-agent.xml
+++ b/harvest-agent-h3/src/main/webapp/WEB-INF/classes/wct-agent.xml
@@ -43,6 +43,20 @@
 			<ref bean="harvestCoordinatorNotifier"></ref>
 		</property>
 	</bean>
+	<bean id="heritrix3WrapperConfiguration" class="org.webcurator.core.harvester.agent.Heritrix3WrapperConfiguration" abstract="false" singleton="true" lazy-init="default" autowire="default" dependency-check="default">
+		<!-- H3 instance host name or ip address for the H3 agent -->
+		<property name="host" value="${h3Wrapper.host}"/>
+		<!-- the port the H3 instance is listening on for http connections -->
+		<property name="port" value="${h3Wrapper.port}"/>
+		<!-- the full path and filename for the keystore file -->
+		<property name="keyStoreFile" value="${h3Wrapper.keyStoreFile}"/>
+		<!-- the password for the keystore file -->
+		<property name="keyStorePassword" value="${h3Wrapper.keyStorePassword}"/>
+		<!-- the userName for the H3 instance -->
+		<property name="userName" value="${h3Wrapper.userName}"/>
+		<!-- the password for the H3 instance -->
+		<property name="password" value="${h3Wrapper.password}"/>
+	</bean>
 	<bean id="harvestCoordinatorNotifier" class="org.webcurator.core.harvester.coordinator.HarvestCoordinatorNotifier" abstract="false" singleton="true" lazy-init="default" autowire="default" dependency-check="default">
 		<!-- the name of the core harvest agent listener web service -->
 		<property name="service" value="${harvestCoordinatorNotifier.service}"/>

--- a/harvest-agent-h3/src/test/java/org/webcurator/core/harvester/agent/HarvestAgentH3Test.java
+++ b/harvest-agent-h3/src/test/java/org/webcurator/core/harvester/agent/HarvestAgentH3Test.java
@@ -9,6 +9,12 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.web.context.WebApplicationContext;
+import org.webcurator.core.common.Environment;
+import org.webcurator.core.util.ApplicationContextFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -19,8 +25,15 @@ import java.util.Map;
 /**
  * HarvestAgentH3 test class.
  */
-
+@RunWith(MockitoJUnitRunner.class)
 public class HarvestAgentH3Test {
+
+    @Mock
+    WebApplicationContext context;
+    @Mock
+    private Environment mockEnvironment;
+    @Mock
+    private Heritrix3WrapperConfiguration mockHeritrix3WrapperConfiguration;
 
     protected static Log log = LogFactory.getLog(HarvestAgentH3Test.class);
     HarvestAgentH3 hah3;
@@ -29,6 +42,18 @@ public class HarvestAgentH3Test {
     public void setUp() throws Exception {
         log.debug("Setting up HarvestAgentH3Test.");
         hah3 = new HarvestAgentH3();
+
+        when(context.getBean("environment")).thenReturn(mockEnvironment);
+        ApplicationContextFactory.setWebApplicationContext(context);
+
+        // We mock the previous behaviour before the bean existed.
+        when(context.getBean("heritrix3WrapperConfiguration")).thenReturn(mockHeritrix3WrapperConfiguration);
+        when(mockHeritrix3WrapperConfiguration.getHost()).thenReturn("localhost");
+        when(mockHeritrix3WrapperConfiguration.getPort()).thenReturn(8443);
+        when(mockHeritrix3WrapperConfiguration.getKeyStoreFile()).thenReturn(null);
+        when(mockHeritrix3WrapperConfiguration.getKeyStorePassword()).thenReturn("");
+        when(mockHeritrix3WrapperConfiguration.getUserName()).thenReturn("admin");
+        when(mockHeritrix3WrapperConfiguration.getPassword()).thenReturn("admin");
     }
 
     @Test


### PR DESCRIPTION
Add properties to the harvest-agent-h3 wct-agent.properties to support specific
H3 configuration.

Notes:
- Any documentation changes will be done in the docs_update_for_v2 branch.
- This does not support multiple H3 instances for each agent, as the
  bean heritrix3WrapperConfiguration is a singleton. More code changes would
  be necessary to support many H3 instances for each H3 agent.

These changes involved multiple steps:

local_config.properties:
- The properties file containing the H3 instance properties: host, port,
  keyStoreFile, keyStorePassword, userName and password.

wct-agent.properties:
- Add the properties for the H3 instance that maps the keys/values found in
  local_config.properties to the keys/values in wct-agent.xml.

wct-agent.xml:
- Map those properties to the bean heritrix3WrapperConfiguration, which maps to
  the class Heritrix3WrapperConfiguration.

Constants.java:
- Added HERITRIX3_WRAPPER_CONFIGURATION to reference the bean
  heritrix3WrapperConfiguration. This is used in HarvestH3.

Heritrix3WrapperConfiguration.java:
- Simple POJO with getters and setters for those properties.

HarvesterH3.java:
- Uses the heritrix3WrapperConfiguration in the getH3WrapperInstance method to
  extract the values for calling the method. Logs information message with
  values.
- Made the log a static instance so it can be used in static methods.
- build method includes informative messages when the job cannot be found. This
  will happen if, for example, the H3 instance has a different username or
  password.

HarvestAgentH3Test.java:
- Mock the bean heritrix3WrapperConfiguration so the unit test works.