### PR TITLE
target-profile.jsp and qa-ti-summary.jsp work with IE 11.

### DIFF
--- a/wct-core/src/main/webapp/jsp/qa-ti-summary.jsp
+++ b/wct-core/src/main/webapp/jsp/qa-ti-summary.jsp
@@ -228,7 +228,10 @@ function onChangeScheduleDates(textbox) {
 	enableButton('discardchanges');
 }
 
-function toggleProfileOverrides(profilesList, onPageLoad=false) {
+function toggleProfileOverrides(profilesList, onPageLoad) {
+    if (onPageLoad == undefined) {
+        onPageLoad = false
+    }
     if (!onPageLoad && currentProfileIndex >= 0) {
         // Save any h3RawProfile editor changes
         profilesList[currentProfileIndex].h3RawProfile = codeMirrorInstance.getValue();

--- a/wct-core/src/main/webapp/jsp/target-profile.jsp
+++ b/wct-core/src/main/webapp/jsp/target-profile.jsp
@@ -79,7 +79,10 @@
   }
 
 
-function toggleProvideOverrides(profilesList, harvesterTypeValueSelected, onPageLoad=false) {
+function toggleProvideOverrides(profilesList, harvesterTypeValueSelected, onPageLoad) {
+    if (onPageLoad == undefined) {
+        onPageLoad = false;
+    }
     if (!onPageLoad && currentProfileIndex >= 0) {
         // Save any h3RawProfile editor changes
         profilesList[currentProfileIndex].h3RawProfile = codeMirrorInstance.getValue();
@@ -609,7 +612,7 @@ No overrides.
 <authority:showControl ownedObject="${ownable}" privileges="${privlege}" editMode="${profileEditMode}">
 <authority:show>
 <div id="editorDiv">
-<textarea id="h3RawProfile" name="h3RawProfile"/>
+<textarea id="h3RawProfile" name="h3RawProfile">
 <c:out value="${command.h3RawProfile}"/>
 </textarea>
 </div>
@@ -623,7 +626,7 @@ No overrides.
 <authority:dont>
 <c:if test="${command.harvesterType == 'HERITRIX3' && command.overrideH3RawProfile}">
 <div id="editorDiv">
-<textarea id="h3RawProfile" name="h3RawProfile"/>
+<textarea id="h3RawProfile" name="h3RawProfile">
 <c:out value="${command.h3RawProfile}"/>
 </textarea>
 </div>


### PR DESCRIPTION
- IE 11 is not EcmaScript6 complicant, so doesn't support function parameter
  defaults. Convert function call to check for undefined and replace with
  default if necessary.

- Corrected some textarea tags that were prematurely closed.

Fixes https://github.com/DIA-NZ/webcurator/issues/83