### PR TITLE
Update maven-compiler-plugin source and target to Java 1.8.

### DIFF
--- a/harvest-agent-h1/pom.xml
+++ b/harvest-agent-h1/pom.xml
@@ -29,8 +29,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.5.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/harvest-agent-h3/pom.xml
+++ b/harvest-agent-h3/pom.xml
@@ -29,8 +29,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.5.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
 				<version>2.0</version>
 				<configuration>
 					<verbose>true</verbose>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/wct-core/pom.xml
+++ b/wct-core/pom.xml
@@ -51,8 +51,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.5.1</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/wct-store/pom.xml
+++ b/wct-store/pom.xml
@@ -29,8 +29,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.5.1</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Web Curator Tool 2.0.0 runs under Java 8. Update the maven-compiler-plugin
configuration to reflect this.