### PR TITLE
POM version updates for 2.0.1 + release notes adjusted.

### DIFF
--- a/docs/guides/release-notes.rst
+++ b/docs/guides/release-notes.rst
@@ -20,7 +20,9 @@ Contents of this document
 Following this introduction, the Web Curator Tool Release Notes includes the
 following sections:
 
--   **Changes since 2.0.0** - Changes since the last official release *2.0.0*.
+-   **Changes since 2.0.1** - Changes since the last official release *2.0.1*.
+
+-   **2.0.1** - Release 2.0.1.
 
 -   **2.0.0** - Release 2.0.0.
 
@@ -39,11 +41,15 @@ following sections:
 -   **Previous versions** - Versions prior to release 1.5.
 
 
-Changes since 2.0.0
+Changes since 2.0.1
 ===================
 
-This is a placeholder for changes since the official *2.0.0* release. Please
+This is a placeholder for changes since the official *2.0.1* release. Please
 add notes here for changes and fixes as they are released into the master branch.
+
+
+2.0.1
+=====
 
 -   The SOAP implementation has changed. As part of that change, the ex-libris Rosetta SDK dependency has moved from
     `2.2.0` to `5.5.0`. This means that the `dps-sdk-5.5.0.jar` must be installed in a local Maven repository for the

--- a/harvest-agent-h1/pom.xml
+++ b/harvest-agent-h1/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>wct-parent</artifactId>
 		<groupId>org.webcurator</groupId>
-		<version>2.0.0</version>
+		<version>2.0.1</version>
 	</parent>
 
     <properties>
@@ -434,7 +434,7 @@
 		<dependency>
 			<groupId>org.webcurator</groupId>
 			<artifactId>wct-core</artifactId>
-			<version>2.0.0</version>
+			<version>2.0.1</version>
 			<scope>compile</scope>
 			<exclusions>
 				<!-- Exclude commons-httpclient brought in via wct-core. We want the version that is tied to

--- a/harvest-agent-h3/pom.xml
+++ b/harvest-agent-h3/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>wct-parent</artifactId>
 		<groupId>org.webcurator</groupId>
-		<version>2.0.0</version>
+		<version>2.0.1</version>
 	</parent>
 
     <properties>
@@ -474,7 +474,7 @@
 		<dependency>
 			<groupId>org.webcurator</groupId>
 			<artifactId>wct-core</artifactId>
-			<version>2.0.0</version>
+			<version>2.0.1</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.webcurator</groupId>
 	<artifactId>wct-parent</artifactId>
-	<version>2.0.0</version>
+	<version>2.0.1</version>
 	<packaging>pom</packaging>
 	<name>Web curator tool parent</name>
 

--- a/wct-assembly/pom.xml
+++ b/wct-assembly/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>wct-parent</artifactId>
 		<groupId>org.webcurator</groupId>
-		<version>2.0.0</version>
+		<version>2.0.1</version>
 	</parent>
 
     <properties>

--- a/wct-core/pom.xml
+++ b/wct-core/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<artifactId>wct-parent</artifactId>
 		<groupId>org.webcurator</groupId>
-		<version>2.0.0</version>
+		<version>2.0.1</version>
 	</parent>
 
 	<properties>

--- a/wct-store/pom.xml
+++ b/wct-store/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>wct-parent</artifactId>
 		<groupId>org.webcurator</groupId>
-		<version>2.0.0</version>
+		<version>2.0.1</version>
 	</parent>
 
     <properties>
@@ -446,7 +446,7 @@
 		<dependency>
 			<groupId>org.webcurator</groupId>
 			<artifactId>wct-core</artifactId>
-			<version>2.0.0</version>
+			<version>2.0.1</version>
 			<scope>compile</scope>
             <!-- Prevent aheritrix.jar being dragged in from wct-core and conflicting with webarchive-commons -->
 			<exclusions>
@@ -482,7 +482,7 @@
 		<dependency>
 			<groupId>org.webcurator</groupId>
 			<artifactId>wct-submit-to-rosetta</artifactId>
-			<version>2.0.0</version>
+			<version>2.0.1</version>
 			<scope>compile</scope>
 			<exclusions>
 				<exclusion>

--- a/wct-submit-to-rosetta/pom.xml
+++ b/wct-submit-to-rosetta/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<artifactId>wct-parent</artifactId>
 		<groupId>org.webcurator</groupId>
-		<version>2.0.0</version>
+		<version>2.0.1</version>
 	</parent>
 
     <properties>


### PR DESCRIPTION
All pom files updated with 2.0.1 from 2.0.0, just needs a test build of parent pom.
Release notes adjusted to include 2.0.1 version. 