### PR TITLE
Adding .gitattributes to blacklist files for release.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+wct-core/etc/photoshop export-ignore
+wct-core/src/test export-ignore
+wct-core/docs export-ignore
+docs export-ignore
+.git export-ignore
+.travis.yml export-ignore
+.gitignore export-ignore
+.gitattributes export-ignore


### PR DESCRIPTION
Here's a solution to #107.

Use `.gitattributes` to exclude some files and directories from releases.

Of course, the content of `.gitattributes` needs to be adapted by someone who knows webcurator...