### PR TITLE
Feature/109 stopping state freeze

### DIFF
--- a/harvest-agent-h3/src/main/java/org/webcurator/core/harvester/agent/HarvestAgentH3.java
+++ b/harvest-agent-h3/src/main/java/org/webcurator/core/harvester/agent/HarvestAgentH3.java
@@ -363,7 +363,7 @@ public class HarvestAgentH3 extends AbstractHarvestAgent implements LogProvider 
 
                 // Don't retry in this situation, just log and continue
                 if (numberOfFiles == 0) {
-                    log.error("Failed to find harvest path for job " + aJob);
+                    log.error("Failed to find WARC files for job " + aJob);
                 } else {
                     for (int i = 0; i < numberOfFiles; i++) {
                         log.debug("Sending ARC " + (i + 1) + " of " + numberOfFiles + " to digital asset store for job " + aJob);

--- a/harvest-agent-h3/src/main/java/org/webcurator/core/harvester/agent/HarvestAgentH3.java
+++ b/harvest-agent-h3/src/main/java/org/webcurator/core/harvester/agent/HarvestAgentH3.java
@@ -390,7 +390,7 @@ public class HarvestAgentH3 extends AbstractHarvestAgent implements LogProvider 
 
                 // Don't retry in this situation, just log and continue
                 if (numberOfFiles == 0) {
-                    log.error(String.format("Failed to find logs for job %s (path: %s) ", aJob, harvester.getHarvestLogDir()));
+                    log.error(String.format("Failed to find logs for job %s (path: %s) ", aJob, harvester.getHarvestLogDir().getAbsolutePath()));
                 } else {
                     for (int i = 0; i < fileList.length; i++) {
                         digitalAssetStore.save(aJob, Constants.DIR_LOGS, fileList[i]);

--- a/harvest-agent-h3/src/main/java/org/webcurator/core/harvester/agent/HarvestAgentH3.java
+++ b/harvest-agent-h3/src/main/java/org/webcurator/core/harvester/agent/HarvestAgentH3.java
@@ -390,7 +390,7 @@ public class HarvestAgentH3 extends AbstractHarvestAgent implements LogProvider 
 
                 // Don't retry in this situation, just log and continue
                 if (numberOfFiles == 0) {
-                    log.error("Failed to find logs path for job " + aJob);
+                    log.error(String.format("Failed to find logs for job %s (path: %s) ", aJob, harvester.getHarvestLogDir()));
                 } else {
                     for (int i = 0; i < fileList.length; i++) {
                         digitalAssetStore.save(aJob, Constants.DIR_LOGS, fileList[i]);
@@ -415,7 +415,7 @@ public class HarvestAgentH3 extends AbstractHarvestAgent implements LogProvider 
 
                 // Don't retry in this situation, just log and continue
                 if (numberOfFiles == 0) {
-                    log.error("Failed to find reports path for job " + aJob);
+                    log.error(String.format("Failed to find reports path for job %s (path: %s)", aJob, reportsDir.getAbsolutePath()));
                 } else {
                     for (int i = 0; i < fileList.length; i++) {
                         digitalAssetStore.save(aJob, Constants.DIR_REPORTS, fileList[i]);


### PR DESCRIPTION
Fix for #109. When files in the Heritrix job directory are missing, we simply log this as an error and continue, letting the job enter the Harvested state without those files (logs, reports or WARCs).

If feel this is a temporary solution. We may want to review the state bookkeeping of target instances, perhaps add an Error state?